### PR TITLE
🐛 Bug fixes and floats

### DIFF
--- a/interpreter.lua
+++ b/interpreter.lua
@@ -18,7 +18,7 @@ function interpreter.interpret(code)
   ------------------------
   -- Interpret the code --
   ------------------------
-  repeat
+  while tp <= #token_list do
     if token.name == ">" then
       tp = tp + 1
       token = token_list[tp]
@@ -127,7 +127,7 @@ function interpreter.interpret(code)
     -- Update the tp-
     tp = tp + 1
     token = token_list[tp]
-  until tp > #token_list
+  end
 end
 
 return interpreter

--- a/test.lua
+++ b/test.lua
@@ -25,6 +25,11 @@ function runTest(code, start_stack, expected_stack, test_name)
     end
 end
 
+print("     Empty Program")
+print("=======================")
+runTest("", {}, {}, "Empty Program")
+
+print()
 print("Individual Instructions")
 print("=======================")
 
@@ -32,7 +37,7 @@ runTest(">1", {}, {1}, "Push 1")
 runTest(">94", {}, {94}, "Push a 2 digit number")
 runTest(">1>2>3", {}, {1, 2, 3}, "Push 1, 2, 3")
 
-runTest("<", {1, 2, 3}, {1, 2}, "Push then pop")
+runTest("<", {1, 2, 3}, {1, 2}, "Pop from the stack")
 
 runTest("+", {7, 8}, {15}, "Add 2 positive integers")
 
@@ -42,20 +47,20 @@ runTest("*", {7, 8}, {56}, "Multiply 2 positive integers")
 
 runTest("/", {4, 8}, {2}, "Divide positive integer multiple")
 
-runTest("%", {23, 8}, {7}, "Modulo 2 positive integers")
+runTest("%", {8, 23}, {7}, "Modulo 2 positive integers")
 
 runTest("^", {2, 5}, {25}, "Square an integer")
 
-runTest("v", {25}, {5}, "Square root an integer")
+runTest("z", {25}, {5}, "Square root an integer")
 
 runTest("@", {7, 8}, {8, 7}, "Swap")
 
 runTest(":", {7}, {7, 7}, "Duplicate")
 
-runTest("£", {}, {}, "Reverse no elements")
-runTest("£", {1}, {1}, "Reverse one element")
-runTest("£", {1, 2}, {2, 1}, "Reverse 2 elements")
-runTest("£", {"test", 73, true}, {true, 73, "test"}, "Reverse various elements")
+runTest("$", {}, {}, "Reverse no elements")
+runTest("$", {1}, {1}, "Reverse one element")
+runTest("$", {1, 2}, {2, 1}, "Reverse 2 elements")
+runTest("$", {"test", 73, true}, {true, 73, "test"}, "Reverse various elements")
 
 print()
 for _, unpassedTest in ipairs(testResults) do

--- a/testTokens.lua
+++ b/testTokens.lua
@@ -100,18 +100,26 @@ function addTest(c, e)
     table.insert(tests, {code=c, expected=e})
 end
 
+addTest("h", {})
+addTest("", {})
 addTest(">1", {{name=">"}, {name="number", value=1}})
+addTest(">1\n", {{name=">"}, {name="number", value=1}})
+addTest("> 1", {{name=">"}, {name="number", value=1}})
+addTest("1 > 1", {{name=">"}, {name="number", value=1}})
+addTest(">f1", {{name=">"}, {name="number", value=1}})
+addTest(">f1.1", {{name=">"}, {name="number", value=1.1}})
+addTest(">1.", {{name=">"}, {name="number", value=1}, {name="."}})
+addTest(">f1.1.", {{name=">"}, {name="number", value=1.1}, {name="."}})
 addTest(">1>2", {{name=">"}, {name="number", value=1}, {name=">"}, {name="number", value=2}})
 addTest(">27>35", {{name=">"}, {name="number", value=27}, {name=">"}, {name="number", value=35}})
 addTest(">27", {{name=">"}, {name="number", value=27}})
 addTest(">\"27\"", {{name=">"}, {name="string", value="27"}})
+addTest(">'27'", {{name=">"}, {name="string", value="27"}})
 addTest(">|27|", {{name=">"}, {name="variable", value="27"}})
 addTest("[]", {{name="[", indentation=1, jump=2}, {name="]", indentation=1, jump=1}})
 addTest("[[]]", {{name="[", indentation=1, jump=4},
                  {name="[", indentation=2, jump=3},
                  {name="]", indentation=2, jump=2},
                  {name="]", indentation=1, jump=1}})
-addTest(">1\n", {{name=">"}, {name="number", value=1}})
-addTest("h", {})
 
 runTests(tests)


### PR DESCRIPTION
You can now do `>f1.1` to push `1.1`! Strings can now use single quotes! And the tokeniser should handle whitesapce better.
Fixed bugs:
- interpreter crashed if given no tokens
- tokeniser did loop with a nil character - this had no negative effect, it just shouldn't do it
- some tests used old syntax or were plain wrong